### PR TITLE
Append CMAKE_Fortran_FLAGS instead of overwrite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
     #set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -O0 -g -traceback -no-wrap-margin -assume byterecl")
 # GNU
 else (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-    set (CMAKE_Fortran_FLAGS "-cpp -O2 -ffast-math -funroll-loops -fall-intrinsics -Wall -fcheck=all")
+    set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -O2 -ffast-math -funroll-loops -fall-intrinsics -Wall -fcheck=all")
     #set (CMAKE_Fortran_FLAGS "-cpp -O0 -g -fbacktrace -fall-intrinsics -Wall -fcheck=all")
 endif (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
 


### PR DESCRIPTION
I was helping a student compile your software and I wasn't able to add `CMAKE_Fortran_FLAGS` to include an FFTW3 outside of `/usr/include`. This change allows me to `cmake -DCMAKE_Fortran_FLAGS="-I ..." ..` and successfully build the project.