### PR TITLE
Compilation bugs fix

### DIFF
--- a/io.f90
+++ b/io.f90
@@ -735,10 +735,6 @@ real(rprec), dimension(:,:,:), allocatable :: pres_real
 #ifndef PPCGNS
 character(64) :: bin_ext
 
-#ifdef PPLVLSET
-real(rprec), allocatable, dimension(:,:,:) :: fx_tot, fy_tot, fz_tot
-#endif
-
 #ifdef PPMPI
 call string_splice(bin_ext, '.c', coord, '.bin')
 #else
@@ -1078,6 +1074,8 @@ subroutine force_tot()
 use mpi_defs, only : mpi_sync_real_array, MPI_SYNC_DOWN
 #endif
 implicit none
+
+real(rprec), allocatable, dimension(:,:,:) :: fx_tot, fy_tot, fz_tot
 
 ! Zero bogus values
 fx(:,:,nz) = 0._rprec

--- a/level_set.f90
+++ b/level_set.f90
@@ -122,8 +122,8 @@ implicit none
 
 character (*), parameter :: sub_name = mod_name // '.level_set_init'
 
-character (*), parameter :: fphi_in_base = path // 'phi.out'
-character (*), parameter :: fnorm_out_base = path // 'norm.dat'
+character (:), allocatable :: fphi_in_base 
+character (:), allocatable :: fnorm_out_base 
 character (*), parameter :: MPI_suffix = '.c'
 
 integer, parameter :: lun = 1
@@ -139,7 +139,8 @@ logical :: exst, opn
 real (rp) :: x, y, z
 
 !---------------------------------------------------------------------
-
+allocate(fphi_in_base, source = path // 'phi.out')
+allocate(fnorm_out_base, source = path // 'norm.dat')
 
 ! This is extremely kludgy. This function will write to phi.out, which will
 ! subsequently be read in. Future developers should fix this.
@@ -281,7 +282,7 @@ use param, only : up, down, ierr, MPI_RPREC, status, comm, coord
 implicit none
 
 character (*), parameter :: sub_name = mod_name // '.level_set_vel_err'
-character(*), parameter :: fname_write = path // 'output/level_set_vel_err.dat'
+character(:), allocatable :: fname_write
 
 integer :: i,j,k
 integer :: uv_err_navg, w_err_navg
@@ -290,6 +291,8 @@ real(rprec) :: u_err, v_err, w_err
 real(rprec) :: u_err_global, v_err_global, w_err_global
 #endif
 integer :: fid
+
+allocate(fname_write, source = path // 'output/level_set_vel_err.dat')
 
 !  Initialize values
 uv_err_navg = 0
@@ -793,7 +796,7 @@ use sim_param, only : u, v, w, txx, txy, txz, tyy, tyz, tzz
 implicit none
 
 character (*), parameter :: sub_name = mod_name // '.extrap_tau_simple'
-character (*), parameter :: fprefix = path // 'output/extrap_tau_simple.'
+character (:), allocatable :: fprefix
 character (*), parameter :: fmta3r = '(a,3(es12.5,1x))'
 character (*), parameter :: fmta3i = '(a,3(i0,1x))'
 
@@ -825,6 +828,8 @@ real (rp) :: txx2, txy2, txz2, tyy2, tyz2, tzz2
 real (rp) :: wgt
 real (rp) :: x(nd), x1(nd), x2(nd)
 real (rp) :: n_hat(nd)
+
+allocate(fprefix, source = path // 'output/extrap_tau_simple.')
 
 !---------------------------------------------------------------------
 ! Set default values
@@ -3037,7 +3042,7 @@ implicit none
 ! include 'tecryte.h'
 
 character (*), parameter :: sub_name = mod_name // '.level_set_global_CA'
-character (*), parameter :: fCA_out = path // 'output/global_CA.dat'
+character (:), allocatable :: fCA_out
 
 integer, parameter :: lun = 99  !--keep open between calls
 
@@ -3049,6 +3054,8 @@ real (rp) :: Uinf   !--velocity scale used in calculation of CA
 real (rp) :: CxA, CyA, CzA ! Normalized for coefficients times frontal area
 real (rp) :: f_Cx, f_Cy, f_Cz      !--drag and lift forces
 real (rp) :: f_Cx_global, f_Cy_global, f_Cz_global, Uinf_global
+
+allocate(fCA_out, source = path // 'output/global_CA.dat')
 
 !---------------------------------------------------------------------
 
@@ -3745,7 +3752,7 @@ use sim_param, only : u, v, w, txx, txy, txz, tyy, tyz, tzz,             &
 implicit none
 
 character (*), parameter :: sub_name = mod_name // '.interp_tau'
-character (*), parameter :: fprefix = path // 'output/interp_tau.'
+character (:), allocatable :: fprefix
 character (*), parameter :: fmta3r = '(a,3(es12.5,1x))'
 character (*), parameter :: fmta3i = '(a,3(i0,1x))'
 
@@ -3780,7 +3787,7 @@ real (rp) :: x(nd), xv(nd)
 character(1024) :: msg
 
 !---------------------------------------------------------------------
-
+allocate(fprefix, source = path // 'output/interp_tau.')
 
 ! Set default values
 imn = 1

--- a/time_average.f90
+++ b/time_average.f90
@@ -322,7 +322,7 @@ end subroutine compute
 subroutine finalize(this)
 !*******************************************************************************
 use grid_m
-use param, only : write_endian, lbz, path, coord, nproc
+use param, only : write_endian, lbz, path, coord, nproc, nz_tot
 use string_util
 #ifdef PPMPI
 use mpi_defs, only : mpi_sync_real_array,MPI_SYNC_DOWNUP
@@ -540,7 +540,7 @@ call write_parallel_cgns(fname_vort,nx,ny,nz- nz_end,nz_tot,                   &
     (/ 'VorticityX', 'VorticityY', 'VorticityZ' /),                            &
     (/ this%vortx(1:nx,1:ny,1:nz-nz_end),                                      &
        this%vorty(1:nx,1:ny,1:nz-nz_end),                                      &
-       this%vortz(1:nx,1:ny,1:nz-nz_end) /)
+       this%vortz(1:nx,1:ny,1:nz-nz_end) /))
 
 #else
 ! Write binary data

--- a/trees_pre_ls.f90
+++ b/trees_pre_ls.f90
@@ -33,11 +33,11 @@ use trees_global_fmask_ls, only : global_fmask_init, calc_global_fmask_ta
 implicit none
 
 !character (*), parameter :: ftrees_conf = path // 'trees.conf'
-character (*), parameter :: fdraw_out = path // 'draw_tree_array.dat'
-character (*), parameter :: fphi_out = path // 'phi.dat'
-character (*), parameter :: fphi_raw_out = path // 'phi.out'
-character (*), parameter :: fbrindex_out = path // 'brindex.dat'
-character (*), parameter :: fbrindex_raw_out = path // 'brindex.out'
+character (:), allocatable :: fdraw_out 
+character (:), allocatable :: fphi_out 
+character (:), allocatable :: fphi_raw_out 
+character (:), allocatable :: fbrindex_out 
+character (:), allocatable :: fbrindex_raw_out 
 
 logical, parameter :: do_write_ascii = .false.
 logical, parameter :: do_calc_global_fmask = .false.
@@ -63,6 +63,11 @@ real (rprec), allocatable :: phi(:, :, :)
 real (rprec) :: x, y, z
 
 !---------------------------------------------------------------------
+allocate(fdraw_out,        source = path // 'draw_tree_array.dat')
+allocate(fphi_out,         source = path // 'phi.dat')
+allocate(fphi_raw_out,     source = path // 'phi.out')
+allocate(fbrindex_out,     source = path // 'brindex.dat')
+allocate(fbrindex_raw_out, source = path // 'brindex.out')
 
 ! Now load the lesgo case information from lesgo.conf
 call read_input_conf()


### PR DESCRIPTION
Three types of bugs were found  in compilation stage.

1. Syntax error
In param.f90, the type of PATH was changed from a parameter to a variable. This increases the flexibility of naming a path. However, a variable string (character) cannot be used to concatenate to a new string in preamble part of a subroutine. It causes the following error:

character (*), parameter :: fdraw_out = path // 'draw_tree_array.dat'. 
                                                           1
Parameter ‘path’ at (1) has not been declared or is a variable, which does not reduce to a constant expression. 

To eliminate this error, the new strings concatenated  with PATH are declared as an allocatable character type and then allocated and assigned in the main body part of the subroutines. Hence the following two files were modified accordingly.  
* level_set.f90
* tree_pre_ls.f90

2. Typo
 * time_average.f90:  (1) L543: error in argument list with an active CGNS flag. A `)` missed. (2) L325: no `nz_tot` imported. 
Those errors appeare if we active CGNS output.
 
3. Logical error
* io.f90: L681 subroutine inst_write. Level set preprocessor PPLVLSET directive should be independent to data output format (binary or CGNS). However, PPLVLSET directive was put inside the CGNS directive, which leaves the variables (f?_tot, ?={x, y, z}) undefined with an active PPCGNS flag.  I put the declaration statement {real(rprec), allocatable, dimension(:,:,:) :: fx_tot, fy_tot, fz_tot} into the containing subroutine `force_tot`.